### PR TITLE
new: OWNERS file setup

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - ldegio
+  - gnosek
+reviewers:
+  - ldegio
+  - gnosek


### PR DESCRIPTION
This PR setup an initial OWNERS file.

It's needed for when we'll move this repo inside `falcosecurity` organization.

Other things needed about this topic:
- [x] create [pdig-maintainers](https://github.com/orgs/falcosecurity/teams/pdig-maintainers/) GitHub team 

Just for reference, to be done soon after the move:
- [x] invite @gnosek to the `falcosecurity` organization
- [x] add him to the aforementioned GitHub team
- [ ] add the `pdig` repo to that team's projects

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>