### PR TITLE
Fix for filters with more than 255 syscalls

### DIFF
--- a/pdig.cc
+++ b/pdig.cc
@@ -219,7 +219,7 @@ static struct sock_fprog* build_filter(bool capture_all)
 		BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
 	};
 
-	const size_t CHUNK_SIZE = 16; // must be < 256
+	const size_t CHUNK_SIZE = 255; // must be < 256
 
 	size_t num_chunks = (num_syscalls + CHUNK_SIZE - 1) / CHUNK_SIZE;
 	size_t last_chunk_len = num_syscalls % CHUNK_SIZE;


### PR DESCRIPTION
It's not necessarily an issue right now, but rather a time bomb.
Jumps in BPF are limited to 255 insns. To work around this limit,
we insert a BPF_RET_TRACE insn every 255 syscalls we test
and adjust the jumps so that we always jump forward to the nearest
trace insn.