### PR TITLE
update: add Lorenzo and Leonardo to owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 approvers:
   - ldegio
   - gnosek
+  - leodido
+  - fntlnz
 reviewers:
   - ldegio
   - gnosek


### PR DESCRIPTION
The rationale behind this is that @gnosek is doing lots of things here and needs to get reviews and approvals, on the other hand @ldegio , the other approver usually does not have time to follow the day by day.

I'm proposing myself and @leodido as two new maintainers of this so that we can learn by reviewing and help in getting things merged.

We both have knowledge of the components here and of ptrace, seccomp and seccomp bpf.


Signed-off-by: Lorenzo Fontana <lo@linux.com>