### PR TITLE
Inject getsockname/getpeername syscalls instead of parsing /proc

### DIFF
--- a/pdig.h
+++ b/pdig.h
@@ -1,11 +1,16 @@
 #pragma once
 
+#include <errno.h>
+#include <stdio.h>
 #include <sys/types.h>
 
 int pdig_init_shm();
 void set_pid(pid_t pid);
+void set_direction(bool enter);
 unsigned long ppm_copy_from_user(void* to, const void* from, unsigned long n);
 long ppm_strncpy_from_user(char* to, const char* from, unsigned long n);
+unsigned long copy_to_user(pid_t pid, void* from, void* to, unsigned long n);
+int step(pid_t pid);
 
 #ifdef FILTERING_ENABLED
 uint64_t on_syscall(uint64_t* context, bool is_enter);
@@ -14,3 +19,20 @@ void on_syscall(uint64_t* context, bool is_enter);
 #endif
 
 void record_procexit_event(pid_t tid, pid_t pid);
+
+#define EXPECT(v) do { \
+    int __ret = (v); \
+	if(__ret < 0) { \
+		fprintf(stderr, "%s failed at %s:%d with %d (errno %s)\n", #v, __FILE__, __LINE__, __ret, strerror(errno)); \
+		abort(); \
+	} \
+} while(0)
+
+#ifdef _DEBUG
+#define DEBUG(...) fprintf(stderr, __VA_ARGS__)
+#else
+#define DEBUG(...)
+#endif
+
+#define WARN(fmt, ...) fprintf(stderr, fmt " at %s:%d (errno %s)\n", __VA_ARGS__, __FILE__, __LINE__, strerror(errno))
+


### PR DESCRIPTION
Should provide a massive speedup for network-heavy workloads (e.g. servers)

The original code parses /proc/net/{tcp,udp}{,6} trying to find the local/remote socket IP addresses. Instead, we now inject getsockname/getpeername syscalls into the traced process, which is roughly infinity times faster.

A few observations:
* We can just backtrack %rip two bytes, since we know the process has just executed a syscall instruction and %rip points just past it
* We cannot inject the syscall if we're processing an enter event (this would mean we're executing two syscalls at the same time), so we return -1 instead. This affects sendto and sendmsg.

A sample run:

```
    no pdig | Time taken for tests:   1.370 seconds
     master | Time taken for tests:   42.863 seconds
getXXXXname | Time taken for tests:   2.118 seconds
```

Note that the time for the master branch will vary depending on how many TIME_WAIT connections are there in /proc, so it will generally get slower over time whenever there's high network activity.

Benchmark howto:
1. install this https://www.npmjs.com/package/http-server
2. in the pdig dir: `echo a > asset.bin`
3. in one console: `./pdig <http-server-path>/http-server -s`
4. in another console: `ab -n 2000 -c 1 http://127.0.0.1:8080/asset.bin`