### PR TITLE
Properly support fork() and vfork() syscalls

### DIFF
--- a/pdig.cc
+++ b/pdig.cc
@@ -157,7 +157,7 @@ void handle_syscall(pid_t pid, pdig_process_context& pctx, bool enter)
 			case __NR_clone:
 			case __NR_fork:
 			case __NR_vfork:
-				DEBUG("SYSCALL tid %d clone syscall %d flags=%08lx\n", pid, syscall_nr, context[CTX_ARG0]);
+				DEBUG("SYSCALL tid %d clone syscall %lu flags=%08lx\n", pid, syscall_nr, context[CTX_ARG0]);
 				pctx.clone_syscall = syscall_nr;
 				pctx.clone_flags = context[CTX_ARG0];
 				// TODO: clone3() will need a dedicated memory region copy_from_user()'d here instead

--- a/udig_procs.c
+++ b/udig_procs.c
@@ -730,7 +730,11 @@ int udig_finish_clone_fill(struct event_filler_arguments *args, scap_threadinfo*
 	//
 	// flags
 	//
-	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+	if(args->event_type == PPME_SYSCALL_CLONE_20_E) {
+		syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+	} else {
+		val = 0;
+	}
 	res = val_to_ring(args, (uint64_t)clone_flags_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;


### PR DESCRIPTION
clone3() will require more elaborate support but libscap support is a prerequisite, so leave it out for now.