### PR TITLE
Allow attaching to whole process trees

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(pdig
 	pdig_ptrace.c
 	pdig_ptrace_amd64.cc
 	pdig_seccomp.cc
+	proc_tree.cc
     udig_procs.c
     ${SYSDIG_DIR}/driver/dynamic_params_table.c
     ${SYSDIG_DIR}/driver/event_table.c

--- a/pdig.cc
+++ b/pdig.cc
@@ -157,7 +157,7 @@ void handle_syscall(pid_t pid, pdig_process_context& pctx, bool enter)
 			case __NR_clone:
 			case __NR_fork:
 			case __NR_vfork:
-				DEBUG("SYSCALL tid %d clone syscall %d flags=%08lx\n", pid, syscall_nr, context[CTX_ARG0]);
+				DEBUG("SYSCALL tid %d clone syscall %lu flags=%08lx\n", pid, syscall_nr, context[CTX_ARG0]);
 				pctx.clone_syscall = syscall_nr;
 				pctx.clone_flags = context[CTX_ARG0];
 				// TODO: clone3() will need a dedicated memory region copy_from_user()'d here instead

--- a/pdig.cc
+++ b/pdig.cc
@@ -508,7 +508,13 @@ int main(int argc, char **argv)
 	EXPECT(pdig_init_shm());
 	DEBUG("parent pid = %d\n", getpid());
 
+	main_ctx.need_more_scans = true;
+
 	do {
+		if(!schedule_next_proc_scan_if_needed(main_ctx)) {
+			continue;
+		}
+
 		int status;
 		DEBUG("parent calling waitpid()\n");
 		pid = waitpid(-1, &status, WUNTRACED);
@@ -518,13 +524,6 @@ int main(int argc, char **argv)
 			break;
 		}
 		EXPECT(pid);
-
-		// MASSIVE TODO: this must be time-based, not randomly dependent on syscall timing
-		find_threads_to_attach(main_ctx);
-		if(attach_proc_tree) {
-			find_procs_to_attach(main_ctx);
-		}
-
 		handle_waitpid(pid, status, main_ctx);
 	} while(!main_ctx.procs.empty());
 

--- a/pdig_debug.h
+++ b/pdig_debug.h
@@ -6,6 +6,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define TRY(v) do { \
+    int __ret = (v); \
+	if(__ret < 0) { \
+		fprintf(stderr, "%s failed at %s:%d with %d (errno %s)\n", #v, __FILE__, __LINE__, __ret, strerror(errno)); \
+	} \
+} while(0)
+
 #define EXPECT(v) do { \
     int __ret = (v); \
 	if(__ret < 0) { \

--- a/pdig_proc.h
+++ b/pdig_proc.h
@@ -57,5 +57,8 @@ struct pdig_context {
 	std::unordered_map<pid_t, size_t> incomplete_mt_procs;
 
 	size_t full_proc_scans_remaining;
+	bool need_more_scans;
+	uint64_t last_scan_ns;
+	int scans_so_far;
 };
 

--- a/pdig_proc.h
+++ b/pdig_proc.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <unordered_map>
+
+struct sock_fprog;
+
+enum class process_state {
+	waiting_for_clone_event,
+	spawning,
+
+	attaching,
+	attaching_first_syscall_enter,
+	attaching_first_syscall_exit,
+
+	waiting_for_enter,
+	waiting_for_exit,
+};
+
+
+struct pdig_process_context {
+	pdig_process_context(process_state state_, bool use_seccomp_, pid_t pid_):
+		state(state_),
+		pid(pid_),
+		clone_syscall(0),
+		clone_flags(0),
+		use_seccomp(use_seccomp_)
+	{}
+
+	process_state state;
+	pid_t pid; // we know the tid but need to store the pid somewhere
+
+	// after a thread calls clone()/fork()/vfork(), store the flags
+	// here so that we can reconstruct the event in the child
+	// after we receive the ptrace CLONE event
+	// TODO: clone3() needs a struct passed as a pointer so we'll want
+	//       to revisit it, either by storing this struct here,
+	//       or storing the complete scap event
+	unsigned long clone_syscall;
+	uint64_t clone_flags;
+
+	bool use_seccomp;
+};
+
+
+struct pdig_context {
+	pid_t mainpid;
+	int exitcode;
+	struct sock_fprog* seccomp_filter;
+	std::unordered_map<pid_t, pdig_process_context> procs;
+
+	// processes that may still have unattached threads
+	// the value is the number of attempts remaining
+	// once it runs out, we give up with a warning
+	std::unordered_map<pid_t, size_t> incomplete_mt_procs;
+
+	size_t full_proc_scans_remaining;
+};
+

--- a/proc_tree.cc
+++ b/proc_tree.cc
@@ -1,0 +1,256 @@
+#include "proc_tree.h"
+
+#include "pdig_debug.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string>
+#include <sys/ptrace.h>
+#include <unordered_map>
+#include <unordered_set>
+
+using pid2pid_map = std::unordered_map<pid_t, pid_t>;
+using proc_map = std::unordered_map<pid_t, pdig_process_context>;
+
+// works on main thread ids only
+// propagate the result to all other threads in the caller
+static bool need_to_attach(pid_t tgid, const pid2pid_map& tgid_to_parent, const proc_map& procs)
+{
+	if(procs.count(tgid) != 0) {
+		// already attached
+		return false;
+	}
+	while(tgid != 1) {
+		auto parent_tgid = tgid_to_parent.find(tgid);
+		if(parent_tgid == tgid_to_parent.end()) {
+			DEBUG("Could not find parent tgid for tgid %d, skipping thread\n", tgid);
+			return false;
+		}
+
+		if(procs.count(parent_tgid->second) != 0) {
+			// a parent process is attached (or needs to be)
+			// so attach us too
+			return true;
+		}
+
+		tgid = parent_tgid->second;
+	}
+
+	// we've reached pid=1 without finding an attached thread
+	return false;
+}
+
+
+static pid_t get_parent_tgid(pid_t tgid)
+{
+	FILE* proc_pid_status;
+	const std::string proc_pid_task_path = "/proc/" + std::to_string(tgid) + "/status";
+	char buf[256];
+
+	proc_pid_status = fopen(proc_pid_task_path.c_str(), "rb");
+	if(!proc_pid_status) {
+		WARN("Failed to open %s", proc_pid_task_path.c_str());
+		return 0;
+	}
+
+	pid_t ptid = 0;
+	while(fgets(buf, sizeof(buf), proc_pid_status)) {
+		if(!strncmp(buf, "PPid:\t", strlen("PPid:\t"))) {
+			ptid = atol(buf + strlen("PPid:\t"));
+			break;
+		}
+	}
+
+	fclose(proc_pid_status);
+	return ptid;
+}
+
+
+static pid2pid_map build_process_tree()
+{
+	DIR* proc;
+	struct dirent* dentry;
+	pid2pid_map proc_tree;
+
+	proc = opendir("/proc");
+	if(!proc) {
+		WARN("Failed to open %s", "/proc");
+		return proc_tree;
+	}
+
+	while(1) {
+		errno = 0;
+		dentry = readdir(proc);
+		if(!dentry) {
+			break;
+		}
+
+		pid_t tgid = atol(dentry->d_name);
+		if(tgid > 0) {
+			pid_t ptid = get_parent_tgid(tgid);
+			if(ptid > 0) {
+				proc_tree.emplace(tgid, ptid);
+			} else {
+				WARN("Failed to get parent tgid of %d", tgid);
+			}
+		}
+	}
+
+	if(errno != 0) {
+		WARN("Failed to scan %s", "/proc");
+	}
+
+	closedir(proc);
+	return proc_tree;
+}
+
+
+static std::unordered_set<pid_t> get_threads(pid_t tgid)
+{
+	DIR* proc_pid_task;
+	struct dirent* dentry;
+	std::unordered_set<pid_t> threads = { tgid }; // whatever happens, there's at least this thread
+	const std::string proc_pid_task_path = "/proc/" + std::to_string(tgid) + "/task";
+
+	proc_pid_task = opendir(proc_pid_task_path.c_str());
+	if(!proc_pid_task) {
+		WARN("Failed to open %s", proc_pid_task_path.c_str());
+		return threads;
+	}
+
+	while(1) {
+		errno = 0;
+		dentry = readdir(proc_pid_task);
+		if(!dentry) {
+			break;
+		}
+
+		pid_t tid = atol(dentry->d_name);
+		if(tid > 0) {
+			threads.insert(tid);
+		}
+	}
+
+	if(errno != 0) {
+		WARN("Failed to list threads from %s", proc_pid_task_path.c_str());
+	}
+
+	closedir(proc_pid_task);
+	return threads;
+}
+
+
+bool attach_thread(pid_t tid, pid_t tgid, pdig_context& main_ctx)
+{
+	bool use_seccomp = main_ctx.seccomp_filter != nullptr;
+
+	auto it = main_ctx.procs.insert({
+		tid,
+		{
+			process_state::attaching,
+			use_seccomp,
+			tgid
+		}
+	});
+
+	if(it.second) {
+		// try 10 times to find all threads
+		// we expect 1 attempt for single-threaded processes
+		// and 2 for multi-threaded, but if the process
+		// keeps racing us in pthread_create, more attempts
+		// may be needed; eventually we give up as we're
+		// apparently trying to attach to a fork bomb
+		if(tgid) {
+			main_ctx.incomplete_mt_procs.emplace(tgid, 10);
+		}
+
+		DEBUG("PTRACE_ATTACH(tid=%d)\n", tid);
+		EXPECT(ptrace(PTRACE_ATTACH, tid, 0, 0));
+		return true;
+	}
+
+	return false;
+}
+
+
+static size_t _attach_all_threads(pid_t tgid, pdig_context& main_ctx)
+{
+	const auto threads = get_threads(tgid);
+	size_t n_attached = 0;
+	for(auto tid : threads) {
+		if(attach_thread(tid, tgid, main_ctx)) {
+			n_attached++;
+		}
+	}
+
+	return n_attached;
+}
+
+void attach_all_threads(pid_t tgid, pdig_context& main_ctx)
+{
+	auto it = main_ctx.incomplete_mt_procs.find(tgid);
+	if(it == main_ctx.incomplete_mt_procs.end()) {
+		return;
+	}
+
+	auto n_attached = _attach_all_threads(it->first, main_ctx);
+	if(n_attached) {
+		if(--(it->second) == 0) {
+			WARN("Failed to attach to all threads of tgid %d, are you running a fork bomb?", it->first);
+			main_ctx.incomplete_mt_procs.erase(it);
+		}
+	} else {
+		// success, we found all the threads with the previous attempt
+		main_ctx.incomplete_mt_procs.erase(it);
+	}
+}
+
+void find_threads_to_attach(pdig_context& main_ctx)
+{
+	for(auto it = main_ctx.incomplete_mt_procs.begin(); it != main_ctx.incomplete_mt_procs.end(); /**/) {
+		auto n_attached = _attach_all_threads(it->first, main_ctx);
+		if(n_attached) {
+			if(--(it->second) == 0) {
+				WARN("Failed to attach to all threads of tgid %d, are you running a fork bomb?", it->first);
+				it = main_ctx.incomplete_mt_procs.erase(it);
+				continue;
+			}
+		} else {
+			// success, we found all the threads with the previous attempt
+			DEBUG("Yay, found all threads of tgid %d\n", it->first);
+			it = main_ctx.incomplete_mt_procs.erase(it);
+			continue;
+		}
+
+		++it;
+	}
+}
+
+size_t find_procs_to_attach(pdig_context& main_ctx)
+{
+	size_t n_attached = 0;
+
+	if(main_ctx.full_proc_scans_remaining == 0) {
+		main_ctx.incomplete_mt_procs.clear();
+		return 0;
+	}
+
+	--main_ctx.full_proc_scans_remaining;
+
+	const auto proc_tree = build_process_tree();
+	for(const auto& it : proc_tree) {
+		if(need_to_attach(it.first, proc_tree, main_ctx.procs)) {
+			// TODO what if the main thread has exited and tid != tgid?
+			// how does it look in /proc?
+			n_attached += attach_thread(it.first, it.first, main_ctx);
+		}
+	}
+
+	if(n_attached == 0) {
+		DEBUG("Yay, attached to all processes\n");
+		main_ctx.full_proc_scans_remaining = 0;
+	}
+
+	return n_attached;
+}

--- a/proc_tree.cc
+++ b/proc_tree.cc
@@ -166,7 +166,7 @@ bool attach_thread(pid_t tid, pid_t tgid, pdig_context& main_ctx)
 		}
 
 		DEBUG("PTRACE_ATTACH(tid=%d)\n", tid);
-		EXPECT(ptrace(PTRACE_ATTACH, tid, 0, 0));
+		TRY(ptrace(PTRACE_ATTACH, tid, 0, 0));
 		return true;
 	}
 
@@ -241,8 +241,6 @@ size_t find_procs_to_attach(pdig_context& main_ctx)
 	const auto proc_tree = build_process_tree();
 	for(const auto& it : proc_tree) {
 		if(need_to_attach(it.first, proc_tree, main_ctx.procs)) {
-			// TODO what if the main thread has exited and tid != tgid?
-			// how does it look in /proc?
 			n_attached += attach_thread(it.first, it.first, main_ctx);
 		}
 	}

--- a/proc_tree.h
+++ b/proc_tree.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "pdig_proc.h"
+
+// attach a single thread
+// if tgid is unknown, it may be set to zero, but then
+// somebody, somewhere must reset it to a valid value
+// and insert the tgid to main_ctx.incomplete_mt_procs
+bool attach_thread(pid_t tid, pid_t tgid, pdig_context& main_ctx);
+
+// attach all threads of a process, but no child processes
+void attach_all_threads(pid_t tgid, pdig_context& main_ctx);
+
+// try to attach to remaining threads of (multithreaded) processes
+// that we've partially attached to
+void find_threads_to_attach(pdig_context& main_ctx);
+
+// scan /proc, looking for processes that are not attached but should be
+// (children of an attached process)
+// returns the number of new processes found
+size_t find_procs_to_attach(pdig_context& main_ctx);

--- a/proc_tree.h
+++ b/proc_tree.h
@@ -11,11 +11,7 @@ bool attach_thread(pid_t tid, pid_t tgid, pdig_context& main_ctx);
 // attach all threads of a process, but no child processes
 void attach_all_threads(pid_t tgid, pdig_context& main_ctx);
 
-// try to attach to remaining threads of (multithreaded) processes
-// that we've partially attached to
-void find_threads_to_attach(pdig_context& main_ctx);
-
-// scan /proc, looking for processes that are not attached but should be
-// (children of an attached process)
-// returns the number of new processes found
-size_t find_procs_to_attach(pdig_context& main_ctx);
+// check if we need to scan /proc now
+// this call blocks until the next signal arrives or the timeout expires
+// returns true if the main loop can go on calling waitpid()
+bool schedule_next_proc_scan_if_needed(pdig_context& main_ctx);

--- a/udig_procs.c
+++ b/udig_procs.c
@@ -730,7 +730,11 @@ int udig_finish_clone_fill(struct event_filler_arguments *args, scap_threadinfo*
 	//
 	// flags
 	//
-	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+	if(args->event_type == PPME_SYSCALL_CLONE_20_E) {
+		syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+	} else {
+		val = 0;
+	}
 	res = val_to_ring(args, (uint64_t)clone_flags_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;


### PR DESCRIPTION
Sadly, there's no system call we can use to find the relevant threads easily, so we fall back to scanning /proc and building the whole parent-child hierarchy. This is inherently racy, so we repeat the scan until we attach to all the threads or our attempt counter runs out and we give up (the workload is clone-heavy and apparently trying to evade us).

The first scan runs immediately after startup, the next two run 50 ms apart, then we scan /proc every 500 ms until the counter expires.

**Note**: in the expected case (no fork/thread bombs), we should attach to all threads in a process tree after the second scan (or maybe third, depending on the activity of the threads in question).

**Note**: this PR builds on top of https://github.com/falcosecurity/pdig/pull/12 so the diff will make more sense after merging that one.