### PR TITLE
allow to call gettimeofday_ns in debug mode

### DIFF
--- a/proc_tree.cc
+++ b/proc_tree.cc
@@ -268,6 +268,14 @@ static size_t find_procs_to_attach(pdig_context& main_ctx)
 
 static constexpr const uint64_t NSEC_PER_SEC = 1000000000;
 
+static uint64_t gettimeofday_ns()
+{
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+
+    return tv.tv_sec * NSEC_PER_SEC + tv.tv_usec * 1000;
+}
+
 // scan all threads and processes as needed
 // returns true if we want another scan scheduled
 bool scan_procs_and_threads(pdig_context& main_ctx)
@@ -290,14 +298,6 @@ bool scan_procs_and_threads(pdig_context& main_ctx)
 #endif
 
 	return need_more_scans;
-}
-
-static uint64_t gettimeofday_ns()
-{
-	struct timeval tv;
-	gettimeofday(&tv, nullptr);
-
-	return tv.tv_sec * NSEC_PER_SEC + tv.tv_usec * 1000;
 }
 
 static uint64_t time_of_next_scan(int scans_so_far, uint64_t last_scan, uint64_t now)


### PR DESCRIPTION
When I run pdig in debug mode, I got a following build error. With this PR, the error will no longer occur.

```
$ cmake -DCMAKE_BUILD_TYPE=Debug .

/app/pdig/proc_tree.cc: In function 'bool scan_procs_and_threads(pdig_context&)':
/app/pdig/proc_tree.cc:288:17: error: 'gettimeofday_ns' was not declared in this scope; did you mean 'gettimeofday'?
  288 |  uint64_t now = gettimeofday_ns();
      |                 ^~~~~~~~~~~~~~~
      |                 gettimeofday
make[2]: *** [CMakeFiles/pdig.dir/build.make:146: CMakeFiles/pdig.dir/proc_tree.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/pdig.dir/all] Error 2
```